### PR TITLE
Fix marblejs benchmark files, update marblejs to recent version

### DIFF
--- a/benchmarks/middleware/marble.js
+++ b/benchmarks/middleware/marble.js
@@ -21,7 +21,12 @@ for (let i = 0; i < n; i++) {
 
 const server = createServer({
   port: 1337,
-  httpListener: httpListener({ effects, middlewares }),
+  listener: httpListener({ effects, middlewares }),
 });
 
-server().then(() => console.log(`  ${n} middlewares - Marble.js`));
+server.then(() => console.log(`  ${n} middlewares - Marble.js`));
+
+const main = async () =>
+  await (await server)();
+
+main();

--- a/benchmarks/routing/marble.js
+++ b/benchmarks/routing/marble.js
@@ -33,7 +33,12 @@ const app = httpListener({ middlewares, effects });
 
 const server = createServer({
   port: 1337,
-  httpListener: httpListener({ middlewares, effects }),
+  listener: httpListener({ middlewares, effects }),
 });
 
-server().then(() => console.log(`  ${n} endpoints - Marble.js`));
+server.then(() => console.log(`  ${n} endpoints - Marble.js`));
+
+const main = async () =>
+  await (await server)();
+
+main();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Jozef Flakus <hello@jflakus.com>",
   "license": "MIT",
   "dependencies": {
-    "@marblejs/core": "3.0.0-next.78",
+    "@marblejs/core": "3.5.1",
     "express": "^4.16.3",
     "koa": "^2.5.1",
     "restify": "^7.2.1",


### PR DESCRIPTION
Current benchmark repo did not run when following directions and was throwing errors on startup.

PR fixes these errors by adjusting benchmark code while also updating Marble to a more recent version.